### PR TITLE
[DEVOPS-1978] Datadog GitHub Integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,14 @@ on: # rebuild any PRs and main branch changes
 
 jobs:
   build: # make sure build/ci work properly
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+      # Set up Node.js
+      - name: Set up Node.js v16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: |
           npm install
       - run: |

--- a/src/cd-trigger.ts
+++ b/src/cd-trigger.ts
@@ -1,5 +1,10 @@
 import fetch from 'node-fetch'
 
+interface ExtraProps {
+  commit_sha?: string
+  repo_url?: string
+}
+
 function getBaseUrl(): string {
   let url = process.env.BASE_URL
   if (!url)
@@ -34,6 +39,7 @@ export async function triggerCD(
     image_tag: string
     version: string
     env?: string
+    extra?: ExtraProps
   },
   retry_cnt = 0
 ): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,8 @@ async function run(): Promise<void> {
     const imageTag: string = core.getInput('image-tag', {required: true})
     const version: string = core.getInput('version', {required: true})
     const env: string = core.getInput('env')
+    const commitSha: string | undefined = core.getInput('commit-sha')
+    const repoUrl: string | undefined = core.getInput('repo-url')
 
     core.debug(
       `Trigger CD for ${application}, profile: ${profile}, imageTag: ${imageTag}, version: ${version}`
@@ -16,7 +18,11 @@ async function run(): Promise<void> {
       profile,
       image_tag: imageTag,
       version,
-      env: env ? env : undefined
+      env: env ? env : undefined,
+      extra: {
+        commit_sha: commitSha ? commitSha : undefined,
+        repo_url: repoUrl ? repoUrl : undefined
+      }
     })
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
## Proposed Changes
https://github.com/bucketplace/ops-monster-v2/pull/325 ops-monster-v2 에서 manifest에 commit_sha 및 repo_url 키가 존재하고 해당 값이 null 일 아닐 경우 해당 값을 override 가능토록 수정 작업이 진행됐습니다.

변경 사항:
- extra 매개변수 추가:
  - Optional 키로 commit_sha와 repo_url 포함


## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
