### PR TITLE
[DEVOPS-1978] debugging missing commit_sha in workflow

### DIFF
--- a/src/cd-trigger.ts
+++ b/src/cd-trigger.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch'
+import * as core from '@actions/core'
 
 interface ExtraProps {
   commit_sha?: string
@@ -44,6 +45,10 @@ export async function triggerCD(
   retry_cnt = 0
 ): Promise<void> {
   if (retry_cnt > 30) throw Error('max retry attempts over!')
+  
+  core.debug(
+    `Sending request with body: ${JSON.stringify(body)}`
+  )
 
   const res = await fetch(
     `${getBaseUrl()}/api/v1/applications/${application}/cd-trigger/`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run(): Promise<void> {
     const repoUrl: string | undefined = core.getInput('repo-url')
 
     core.debug(
-      `Trigger CD for ${application}, profile: ${profile}, imageTag: ${imageTag}, version: ${version}`
+      `Trigger CD for ${application}, profile: ${profile}, imageTag: ${imageTag}, version: ${version}, env: ${env}, commitSha: ${commitSha}, repoUrl: ${repoUrl}`
     )
     await triggerCD(application, {
       profile,


### PR DESCRIPTION
## Proposed Changes

GitHub workflow에서 `commit_sha` 값이 서버에 올바르게 전송되지 않는 것 같습니다; (추측)

- `commit_sha`, `repo_url` 값을 포함한 요청 `body` 로깅

## Test Status
(테스트를 어떻게 진행했는지 설명합니다.)
